### PR TITLE
Add core CLI gameplay loop for Startup Simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-Startup Simulator
+# Startup Simulator (FinTech Edition)
+
+Startup Simulator is a turn-based strategy and narrative experience that puts you in
+charge of a scrappy FinTech startup. Balance growth, morale, product quality, and
+cashflow while reacting to dynamic events and choosing pivotal monthly actions.
+
+## Requirements
+
+* Python 3.12+
+* No external dependencies – the standard library is enough.
+
+## Getting Started
+
+```bash
+python main.py --seed 1234
+```
+
+The optional `--seed` argument ensures deterministic outcomes for testing and
+comparison runs. You can also load custom data using `--data-path` if you want to
+experiment with your own actions, events, or profiles.
+
+## Gameplay Overview
+
+Each month you will:
+
+1. Review the previous month's highlights and financial summary.
+2. Experience persistent or surprise events that shift your metrics.
+3. Select up to three strategic actions such as hiring, marketing, or shipping features.
+4. Watch the consequences unfold as your company's value, runway, and reputation evolve.
+
+Win by achieving an IPO-level valuation or a lucrative acquisition. Lose if you run out
+of cash or morale and value fail to keep pace. A high-morale neutral exit is also
+possible.
+
+## Saving and Loading
+
+Choose `save` at action prompts or the end-of-month confirmation to write a JSON save
+file. Use the main menu's **Load Game** option to resume from any saved state.

--- a/data/actions.json
+++ b/data/actions.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "hire_staff",
+    "name": "Hire Staff",
+    "cost": 15000,
+    "effects": {
+      "team_size": 1,
+      "productivity": 5,
+      "expenses": 4000,
+      "morale": 2
+    },
+    "description": "Grow the team with a strategic hire."
+  },
+  {
+    "id": "fix_bugs",
+    "name": "Fix Critical Bugs",
+    "cost": 8000,
+    "effects": {
+      "bug_rate": -7,
+      "productivity": -2,
+      "reputation": 2
+    },
+    "description": "Focus the sprint on stability and cleanup."
+  },
+  {
+    "id": "develop_feature",
+    "name": "Develop New Feature",
+    "cost": 12000,
+    "effects": {
+      "product_level": 1,
+      "bug_rate": 3,
+      "users": 400
+    },
+    "description": "Ship a differentiated capability your customers requested."
+  },
+  {
+    "id": "marketing_campaign",
+    "name": "Run Marketing Campaign",
+    "cost": 20000,
+    "effects": {
+      "users": 1500,
+      "market_share": 1.5,
+      "reputation": 4
+    },
+    "description": "Invest in digital ads and content to capture attention."
+  },
+  {
+    "id": "pitch_investor",
+    "name": "Pitch to Investors",
+    "cost": 5000,
+    "effects": {
+      "reputation": 1
+    },
+    "risk": {
+      "success_chance": 0.45,
+      "success_effects": {
+        "balance": 120000,
+        "revenue": 6000,
+        "reputation": 4
+      },
+      "failure_effects": {
+        "reputation": -3,
+        "morale": -4
+      },
+      "success_narrative": "The pitch deck dazzles investors and you close a sizable round!",
+      "failure_narrative": "Investors pass for now, citing product-market fit concerns."
+    },
+    "description": "Seek additional capital to extend runway."
+  },
+  {
+    "id": "team_meeting",
+    "name": "Hold Team Alignment",
+    "cost": 3000,
+    "effects": {
+      "morale": 10,
+      "productivity": 5,
+      "bug_rate": -2
+    },
+    "description": "Host an offsite to reinforce mission and collaboration."
+  },
+  {
+    "id": "cut_costs",
+    "name": "Cut Operational Costs",
+    "cost": 0,
+    "effects": {
+      "expenses": -5000,
+      "morale": -6,
+      "productivity": -5
+    },
+    "description": "Trim vendors and perks to slow burn."
+  },
+  {
+    "id": "launch_product_line",
+    "name": "Launch New Product Line",
+    "cost": 40000,
+    "effects": {
+      "product_level": 2,
+      "revenue": 8000,
+      "bug_rate": 6,
+      "market_share": 3
+    },
+    "risk": {
+      "success_chance": 0.6,
+      "success_effects": {
+        "revenue": 12000,
+        "users": 2500,
+        "reputation": 5
+      },
+      "failure_effects": {
+        "bug_rate": 5,
+        "reputation": -4,
+        "users": -1200
+      },
+      "success_narrative": "The launch delights customers and surges organic adoption!",
+      "failure_narrative": "Launch glitches frustrate early adopters and slow growth."
+    },
+    "description": "Introduce a complementary offering to diversify revenue."
+  }
+]

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "investor_meeting",
+    "name": "Investor Meeting",
+    "trigger_chance": 0.12,
+    "duration": 1,
+    "deltas": {
+      "balance": 30000,
+      "revenue": 5000,
+      "reputation": 5
+    },
+    "narrative": "A venture fund is impressed by your traction and wires a bridge round overnight."
+  },
+  {
+    "id": "server_crash",
+    "name": "Server Crash",
+    "trigger_chance": 0.08,
+    "duration": 2,
+    "deltas": {
+      "bug_rate": 8,
+      "users": -800,
+      "reputation": -6
+    },
+    "revert_deltas": {
+      "bug_rate": -4
+    },
+    "narrative": "An unpatched dependency causes a cascading outage that lasts days."
+  },
+  {
+    "id": "competitor_launch",
+    "name": "Competitor Launch",
+    "trigger_chance": 0.1,
+    "duration": 3,
+    "deltas": {
+      "market_share": -3,
+      "reputation": -2
+    },
+    "narrative": "A well-funded rival unveils a flashy product, tempting away some of your customers."
+  },
+  {
+    "id": "pr_boost",
+    "name": "PR Boost",
+    "trigger_chance": 0.07,
+    "duration": 2,
+    "deltas": {
+      "reputation": 8,
+      "users": 1200
+    },
+    "revert_deltas": {
+      "reputation": -3
+    },
+    "narrative": "Your latest customer success story trends on FinTech Twitter."
+  },
+  {
+    "id": "key_employee_leaves",
+    "name": "Key Employee Leaves",
+    "trigger_chance": 0.06,
+    "duration": 2,
+    "deltas": {
+      "team_size": -1,
+      "productivity": -10,
+      "morale": -8
+    },
+    "narrative": "Your lead engineer accepts an offer from a unicorn and exits abruptly."
+  },
+  {
+    "id": "regulation_change",
+    "name": "Regulation Change",
+    "trigger_chance": 0.05,
+    "duration": 3,
+    "deltas": {
+      "expenses": 7000,
+      "reputation": 4
+    },
+    "revert_deltas": {
+      "expenses": -5000
+    },
+    "narrative": "New compliance requirements demand rapid investment in legal reviews."
+  },
+  {
+    "id": "positive_review",
+    "name": "Viral Positive Review",
+    "trigger_chance": 0.09,
+    "duration": 1,
+    "deltas": {
+      "users": 2200,
+      "reputation": 7
+    },
+    "narrative": "A popular FinTech blogger gushes about your sleek onboarding."
+  },
+  {
+    "id": "fraud_incident",
+    "name": "Fraud Incident",
+    "trigger_chance": 0.04,
+    "duration": 2,
+    "deltas": {
+      "balance": -40000,
+      "reputation": -9,
+      "bug_rate": 5
+    },
+    "narrative": "A sophisticated fraud ring exploits a workflow gap, forcing reimbursements."
+  }
+]

--- a/data/startup_profiles.json
+++ b/data/startup_profiles.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "balanced_founders",
+    "name": "Balanced Founders",
+    "description": "A pragmatic founding duo with strong product and go-to-market instincts.",
+    "stats": {
+      "balance": 200000,
+      "revenue": 12000,
+      "expenses": 32000,
+      "product_level": 1,
+      "bug_rate": 9,
+      "team_size": 5,
+      "morale": 72,
+      "productivity": 80,
+      "reputation": 52,
+      "users": 5500,
+      "market_share": 2.5
+    }
+  },
+  {
+    "id": "growth_hacker",
+    "name": "Growth Hacker",
+    "description": "An ex-accelerator alum obsessed with viral loops and aggressive acquisition.",
+    "stats": {
+      "balance": 160000,
+      "revenue": 15000,
+      "expenses": 36000,
+      "product_level": 1,
+      "bug_rate": 14,
+      "team_size": 4,
+      "morale": 68,
+      "productivity": 78,
+      "reputation": 48,
+      "users": 9000,
+      "market_share": 3.5
+    }
+  },
+  {
+    "id": "compliance_first",
+    "name": "Compliance First",
+    "description": "Former bankers who prioritize trust, safety, and regulatory mastery above all else.",
+    "stats": {
+      "balance": 230000,
+      "revenue": 9000,
+      "expenses": 28000,
+      "product_level": 1,
+      "bug_rate": 7,
+      "team_size": 6,
+      "morale": 74,
+      "productivity": 82,
+      "reputation": 60,
+      "users": 4800,
+      "market_share": 1.8
+    }
+  }
+]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,42 @@
+"""Command line interface entry point for Startup Simulator."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from startup_simulator.game import StartupSimulator
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Play Startup Simulator (FinTech Edition).")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Optional random seed for deterministic runs.",
+    )
+    parser.add_argument(
+        "--data-path",
+        type=Path,
+        default=Path(__file__).parent / "data",
+        help="Path to game data files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Run the Startup Simulator application."""
+
+    args = parse_args()
+    simulator = StartupSimulator(args.data_path, seed=args.seed)
+    try:
+        simulator.run()
+    except KeyboardInterrupt:
+        print("\nSession ended by user.")
+
+
+if __name__ == "__main__":
+    main()

--- a/startup_simulator/__init__.py
+++ b/startup_simulator/__init__.py
@@ -1,0 +1,5 @@
+"""Startup Simulator package."""
+
+from .game import StartupSimulator
+
+__all__ = ["StartupSimulator"]

--- a/startup_simulator/data_loader.py
+++ b/startup_simulator/data_loader.py
@@ -1,0 +1,87 @@
+"""Data loading helpers for Startup Simulator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .models import Action, ActionRisk, Event, StartupProfile
+
+
+def load_events(path: Path) -> List[Event]:
+    """Load events from a JSON file."""
+
+    data = _load_json(path)
+    events: List[Event] = []
+    for item in data:
+        events.append(
+            Event(
+                event_id=item["id"],
+                name=item["name"],
+                trigger_chance=float(item["trigger_chance"]),
+                duration=int(item["duration"]),
+                deltas={key: float(value) for key, value in item["deltas"].items()},
+                narrative=item["narrative"],
+                revert_deltas=
+                    {key: float(value) for key, value in item.get("revert_deltas", {}).items()}
+                    if item.get("revert_deltas")
+                    else None,
+            )
+        )
+    return events
+
+
+def load_actions(path: Path) -> List[Action]:
+    """Load actions from a JSON file."""
+
+    data = _load_json(path)
+    actions: List[Action] = []
+    for item in data:
+        risk_data = item.get("risk")
+        risk = None
+        if risk_data:
+            risk = ActionRisk(
+                success_chance=float(risk_data["success_chance"]),
+                success_effects={
+                    key: float(value) for key, value in risk_data["success_effects"].items()
+                },
+                failure_effects={
+                    key: float(value) for key, value in risk_data["failure_effects"].items()
+                },
+                success_narrative=risk_data["success_narrative"],
+                failure_narrative=risk_data["failure_narrative"],
+            )
+        actions.append(
+            Action(
+                action_id=item["id"],
+                name=item["name"],
+                cost=float(item.get("cost", 0)),
+                effects={key: float(value) for key, value in item.get("effects", {}).items()},
+                description=item.get("description", ""),
+                risk=risk,
+            )
+        )
+    return actions
+
+
+def load_profiles(path: Path) -> List[StartupProfile]:
+    """Load startup profiles from a JSON file."""
+
+    data = _load_json(path)
+    profiles: List[StartupProfile] = []
+    for item in data:
+        profiles.append(
+            StartupProfile(
+                profile_id=item["id"],
+                name=item["name"],
+                description=item.get("description", ""),
+                stats={key: float(value) for key, value in item["stats"].items()},
+            )
+        )
+    return profiles
+
+
+def _load_json(path: Path) -> List[Dict[str, object]]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)

--- a/startup_simulator/game.py
+++ b/startup_simulator/game.py
@@ -1,0 +1,465 @@
+"""Core gameplay loop for Startup Simulator."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .data_loader import load_actions, load_events, load_profiles
+from .models import (
+    Action,
+    ActiveEvent,
+    Event,
+    GameState,
+    GameStats,
+    SCHEMA_VERSION,
+    StartupProfile,
+    default_rng,
+)
+from .utils import clamp, format_currency, format_percentage, join_and, parse_int, wrap_text
+
+
+STATS_RANGES = {
+    "balance": (0.0, float("inf")),
+    "revenue": (0.0, float("inf")),
+    "expenses": (0.0, float("inf")),
+    "product_level": (0.0, 10.0),
+    "bug_rate": (0.0, 100.0),
+    "team_size": (0.0, 500.0),
+    "morale": (0.0, 100.0),
+    "productivity": (0.0, 100.0),
+    "reputation": (0.0, 100.0),
+    "users": (0.0, float("inf")),
+    "market_share": (0.0, 100.0),
+}
+
+
+class StartupSimulator:
+    """Main application controller for the Startup Simulator."""
+
+    def __init__(self, data_path: Path, seed: Optional[int] = None) -> None:
+        self.data_path = data_path
+        self.events = load_events(data_path / "events.json")
+        self.actions = load_actions(data_path / "actions.json")
+        self.profiles = load_profiles(data_path / "startup_profiles.json")
+        self.events_by_id = {event.event_id: event for event in self.events}
+        self.rng = default_rng(seed)
+        self.state: Optional[GameState] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def new_game(self, profile: StartupProfile) -> None:
+        """Start a new game with a chosen profile."""
+
+        stats = self._create_stats_from_profile(profile)
+        self.state = GameState(stats=stats, turn=1)
+        self.state.rng_state = self.rng.getstate()
+        self.state.last_report = [
+            f"You begin your journey as {profile.name}.",
+            profile.description,
+        ]
+
+    def load_game(self, path: Path) -> None:
+        """Load a saved game."""
+
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError("Unsupported save file version.")
+        state_data = payload["state"]
+        state = GameState.from_dict(state_data, self.events_by_id)
+        self.state = state
+        rng_state = state.rng_state
+        if rng_state:
+            self.rng.setstate(rng_state)
+        self._info("Game loaded successfully.")
+
+    def save_game(self, path: Path) -> None:
+        """Persist the current game state to disk."""
+
+        if not self.state:
+            raise ValueError("No active game to save.")
+        self.state.rng_state = self.rng.getstate()
+        payload = {
+            "schema_version": SCHEMA_VERSION,
+            "saved_at": dt.datetime.utcnow().isoformat(),
+            "state": self.state.to_dict(),
+        }
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+        self._info(f"Game saved to {path}.")
+
+    def run(self) -> None:
+        """Run the CLI application."""
+
+        while True:
+            self._print_main_menu()
+            choice = input("> ").strip().lower()
+            if choice == "1":
+                profile = self._choose_profile()
+                if profile:
+                    self.new_game(profile)
+                    self._game_loop()
+            elif choice == "2":
+                path = self._prompt_path("Enter save file path to load: ")
+                try:
+                    self.load_game(path)
+                    self._game_loop()
+                except (FileNotFoundError, ValueError) as error:
+                    self._info(str(error))
+            elif choice == "q":
+                self._info("Goodbye!")
+                break
+            else:
+                self._info("Please choose a valid option.")
+
+    # ------------------------------------------------------------------
+    # Game loop
+    # ------------------------------------------------------------------
+    def _game_loop(self) -> None:
+        assert self.state is not None
+        while True:
+            self._print_turn_header()
+            self._print_last_report()
+            self._process_active_events()
+            self._trigger_random_event()
+            if not self._choose_actions():
+                break
+            self._update_turn()
+            ending = self._check_end_conditions()
+            if ending:
+                self._info(ending)
+                break
+            if not self._prompt_continue():
+                break
+
+    def _print_turn_header(self) -> None:
+        assert self.state is not None
+        print("\n" + "=" * 72)
+        print(f"Month {self.state.turn}")
+        print("=" * 72)
+
+    def _print_last_report(self) -> None:
+        assert self.state is not None
+        if not self.state.last_report:
+            return
+        print("\nLast month's highlights:")
+        for entry in self.state.last_report:
+            print(f"- {wrap_text(entry)}")
+        self.state.last_report.clear()
+
+    def _process_active_events(self) -> None:
+        assert self.state is not None
+        ongoing_reports: List[str] = []
+        still_active: List[ActiveEvent] = []
+        for active in self.state.active_events:
+            self._apply_deltas(active.event.deltas)
+            ongoing_reports.append(
+                f"Event: {active.event.name} persists ({active.remaining_turns} turns left)."
+            )
+            active.remaining_turns -= 1
+            if active.remaining_turns > 0:
+                still_active.append(active)
+            else:
+                if active.event.revert_deltas:
+                    self._apply_deltas(active.event.revert_deltas)
+                ongoing_reports.append(f"Event: {active.event.name} has ended.")
+        self.state.active_events = still_active
+        if ongoing_reports:
+            self._print_event_block("Ongoing events", ongoing_reports)
+            self.state.last_report.extend(ongoing_reports)
+
+    def _trigger_random_event(self) -> None:
+        assert self.state is not None
+        shuffled_events = list(self.events)
+        self.rng.shuffle(shuffled_events)
+        for event in shuffled_events:
+            if self._is_event_active(event.event_id):
+                continue
+            if self.rng.random() <= event.trigger_chance:
+                self._apply_event(event)
+                break
+
+    def _is_event_active(self, event_id: str) -> bool:
+        assert self.state is not None
+        return any(active.event.event_id == event_id for active in self.state.active_events)
+
+    def _apply_event(self, event: Event) -> None:
+        assert self.state is not None
+        self._apply_deltas(event.deltas)
+        report_lines = [f"Event triggered: {event.name}", event.narrative]
+        self.state.last_report.extend(report_lines)
+        self._print_event_block("New event", report_lines)
+        if event.duration > 1:
+            self.state.active_events.append(
+                ActiveEvent(event=event, remaining_turns=event.duration - 1)
+            )
+
+    def _choose_actions(self) -> bool:
+        assert self.state is not None
+        max_actions = 3
+        min_actions = 1
+        action_count = self._prompt_int(
+            f"How many actions will you take this month? ({min_actions}-{max_actions}, 0 to save & exit): ",
+            minimum=0,
+            maximum=max_actions,
+        )
+        if action_count == 0:
+            if self._prompt_save():
+                self._info("Game saved. Returning to main menu.")
+                return False
+            self._info("Save unsuccessful. Continuing the current month.")
+            return True
+        for _ in range(action_count):
+            action = self._prompt_action_choice()
+            if not action:
+                break
+            self._execute_action(action)
+        return True
+
+    def _prompt_action_choice(self) -> Optional[Action]:
+        assert self.state is not None
+        print("\nChoose an action:")
+        for index, action in enumerate(self.actions, start=1):
+            print(f"  {index}. {action.name} - {action.description}")
+            print(f"     Cost: {format_currency(action.cost)}")
+        print("  0. Finish actions early")
+        choice = self._prompt_int("Selection: ", minimum=0, maximum=len(self.actions))
+        if choice == 0:
+            return None
+        return self.actions[choice - 1]
+
+    def _execute_action(self, action: Action) -> None:
+        assert self.state is not None
+        if self.state.stats.balance < action.cost:
+            self.state.last_report.append(
+                f"Insufficient balance for {action.name}. Action skipped."
+            )
+            return
+        self.state.stats.balance -= action.cost
+        self._apply_deltas(action.effects)
+        report_entries = [f"Action taken: {action.name}"]
+        if action.effects:
+            effect_list = self._describe_effects(action.effects)
+            if effect_list:
+                report_entries.append(f"Effects: {effect_list}.")
+        if action.risk:
+            outcome = self.rng.random()
+            if outcome <= action.risk.success_chance:
+                self._apply_deltas(action.risk.success_effects)
+                report_entries.append(action.risk.success_narrative)
+            else:
+                self._apply_deltas(action.risk.failure_effects)
+                report_entries.append(action.risk.failure_narrative)
+        self.state.last_report.extend(report_entries)
+
+    def _describe_effects(self, effects: Dict[str, float]) -> str:
+        parts: List[str] = []
+        for key, value in effects.items():
+            if key in {"balance", "revenue", "expenses"}:
+                prefix = "+" if value >= 0 else "-"
+                formatted = f"{prefix}{format_currency(abs(value))}"
+            elif key in {"market_share", "bug_rate", "morale", "productivity", "reputation"}:
+                prefix = "+" if value >= 0 else "-"
+                formatted = f"{prefix}{format_percentage(abs(value))}"
+            elif key == "users":
+                prefix = "+" if value >= 0 else "-"
+                formatted = f"{prefix}{abs(int(value)):,} users"
+            elif key == "team_size":
+                formatted = f"team size {'+' if value >= 0 else ''}{int(value)}"
+            elif key == "product_level":
+                formatted = f"product level {'+' if value >= 0 else ''}{int(value)}"
+            else:
+                formatted = f"{key} {'+' if value >= 0 else ''}{value}"
+            parts.append(f"{key} {formatted}")
+        return join_and(parts)
+
+    def _update_turn(self) -> None:
+        assert self.state is not None
+        self._clamp_stats()
+        self.state.turn += 1
+        summary = self._build_summary()
+        self.state.last_report.append(summary)
+
+    def _build_summary(self) -> str:
+        assert self.state is not None
+        stats = self.state.stats
+        runway = self._calculate_runway(stats)
+        company_value = self._calculate_company_value(stats)
+        summary = (
+            f"Balance {format_currency(stats.balance)}, "
+            f"Revenue {format_currency(stats.revenue)}, "
+            f"Expenses {format_currency(stats.expenses)}, "
+            f"Runway {runway:.1f} months, Company Value {format_currency(company_value)}"
+        )
+        return summary
+
+    def _clamp_stats(self) -> None:
+        assert self.state is not None
+        stats = self.state.stats
+        for key, (minimum, maximum) in STATS_RANGES.items():
+            value = getattr(stats, key)
+            clamped = clamp(float(value), minimum, maximum)
+            if key in {"product_level", "team_size"}:
+                setattr(stats, key, int(round(clamped)))
+            else:
+                setattr(stats, key, clamped)
+
+    def _calculate_runway(self, stats: GameStats) -> float:
+        burn = stats.expenses - stats.revenue
+        if burn <= 0:
+            return 24.0
+        if stats.expenses == 0:
+            return 24.0
+        months = stats.balance / burn if burn > 0 else 24.0
+        return max(0.0, min(months, 60.0))
+
+    def _calculate_company_value(self, stats: GameStats) -> float:
+        return (
+            (stats.revenue * 4)
+            + (stats.market_share * 2000)
+            + (stats.reputation * 100)
+            + (stats.team_size * 500)
+            - (stats.bug_rate * 50)
+        )
+
+    def _check_end_conditions(self) -> Optional[str]:
+        assert self.state is not None
+        stats = self.state.stats
+        runway = self._calculate_runway(stats)
+        company_value = self._calculate_company_value(stats)
+        if stats.balance <= 0 or runway <= 0:
+            return "Bankruptcy! Your startup ran out of cash."
+        if company_value >= 5_000_000:
+            return "Congratulations! You achieved an IPO-level valuation."
+        if stats.reputation >= 70 and stats.market_share >= 30:
+            return "Acquisition offer accepted! A strategic buyer acquires your company."
+        if company_value >= 1_000_000 and stats.morale >= 80:
+            return "Neutral exit: You sold the company with the team in high spirits."
+        return None
+
+    def _prompt_continue(self) -> bool:
+        while True:
+            choice = input("Continue to next month? (y/n/save): ").strip().lower()
+            if choice in {"y", "yes"}:
+                return True
+            if choice in {"n", "no"}:
+                return False
+            if choice == "save":
+                if self._prompt_save():
+                    return False
+            else:
+                self._info("Please respond with y, n, or save.")
+
+    def _prompt_save(self) -> bool:
+        path = self._prompt_path("Enter save file path: ")
+        try:
+            self.save_game(path)
+            return True
+        except (FileNotFoundError, ValueError) as error:
+            self._info(str(error))
+            return False
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _apply_deltas(self, deltas: Dict[str, float]) -> None:
+        assert self.state is not None
+        for key, value in deltas.items():
+            if hasattr(self.state.stats, key):
+                current = getattr(self.state.stats, key)
+                setattr(self.state.stats, key, current + value)
+
+    def _create_stats_from_profile(self, profile: StartupProfile) -> GameStats:
+        stats = {
+            "balance": 200_000.0,
+            "revenue": 10_000.0,
+            "expenses": 30_000.0,
+            "product_level": 1,
+            "bug_rate": 10.0,
+            "team_size": 5,
+            "morale": 70.0,
+            "productivity": 80.0,
+            "reputation": 50.0,
+            "users": 5_000.0,
+            "market_share": 2.0,
+        }
+        stats.update(profile.stats)
+        return GameStats(
+            balance=float(stats["balance"]),
+            revenue=float(stats["revenue"]),
+            expenses=float(stats["expenses"]),
+            product_level=int(stats["product_level"]),
+            bug_rate=float(stats["bug_rate"]),
+            team_size=int(stats["team_size"]),
+            morale=float(stats["morale"]),
+            productivity=float(stats["productivity"]),
+            reputation=float(stats["reputation"]),
+            users=float(stats["users"]),
+            market_share=float(stats["market_share"]),
+        )
+
+    def _print_main_menu(self) -> None:
+        print("\nStartup Simulator - FinTech Edition")
+        print("1. New Game")
+        print("2. Load Game")
+        print("q. Quit")
+
+    def _choose_profile(self) -> Optional[StartupProfile]:
+        if not self.profiles:
+            self._info("No profiles available.")
+            return None
+        print("\nChoose your founding profile:")
+        for index, profile in enumerate(self.profiles, start=1):
+            print(f"  {index}. {profile.name} - {profile.description}")
+        print("  0. Cancel")
+        choice = self._prompt_int("Selection: ", minimum=0, maximum=len(self.profiles))
+        if choice == 0:
+            return None
+        return self.profiles[choice - 1]
+
+    def _prompt_int(self, prompt: str, minimum: int, maximum: int) -> int:
+        while True:
+            raw = input(prompt)
+            parsed = parse_int(raw)
+            if parsed is None:
+                self._info("Enter a valid number.")
+                continue
+            if parsed < minimum or parsed > maximum:
+                self._info(f"Choose a number between {minimum} and {maximum}.")
+                continue
+            return parsed
+
+    def _prompt_path(self, prompt: str) -> Path:
+        while True:
+            raw = input(prompt).strip()
+            if not raw:
+                self._info("Path cannot be empty.")
+                continue
+            return Path(raw)
+
+    def _info(self, message: str) -> None:
+        print(wrap_text(message))
+
+    def _print_event_block(self, title: str, lines: Iterable[str]) -> None:
+        entries = list(lines)
+        if not entries:
+            return
+        print(f"\n{title}:")
+        for entry in entries:
+            wrapped = wrap_text(entry)
+            lines = wrapped.splitlines()
+            if not lines:
+                continue
+            print(f"  - {lines[0]}")
+            for line in lines[1:]:
+                print(f"    {line}")
+
+
+def list_available_actions(actions: Iterable[Action]) -> List[str]:
+    """Return a formatted list of action names."""
+
+    return [action.name for action in actions]

--- a/startup_simulator/models.py
+++ b/startup_simulator/models.py
@@ -1,0 +1,189 @@
+"""Data models for Startup Simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Tuple
+import random
+
+
+StatDict = Dict[str, float]
+
+
+@dataclass
+class Event:
+    """Represents a time-bound event that influences company stats."""
+
+    event_id: str
+    name: str
+    trigger_chance: float
+    duration: int
+    deltas: StatDict
+    narrative: str
+    revert_deltas: Optional[StatDict] = None
+
+
+@dataclass
+class ActionRisk:
+    """Represents a risky action outcome."""
+
+    success_chance: float
+    success_effects: StatDict
+    failure_effects: StatDict
+    success_narrative: str
+    failure_narrative: str
+
+
+@dataclass
+class Action:
+    """Represents an action that the player can take."""
+
+    action_id: str
+    name: str
+    cost: float
+    effects: StatDict
+    description: str
+    risk: Optional[ActionRisk] = None
+
+
+@dataclass
+class StartupProfile:
+    """Configuration for a starting company profile."""
+
+    profile_id: str
+    name: str
+    description: str
+    stats: StatDict
+
+
+@dataclass
+class ActiveEvent:
+    """Tracks an event currently affecting the company."""
+
+    event: Event
+    remaining_turns: int
+
+
+@dataclass
+class GameStats:
+    """Holds the numeric metrics for the company."""
+
+    balance: float
+    revenue: float
+    expenses: float
+    product_level: int
+    bug_rate: float
+    team_size: int
+    morale: float
+    productivity: float
+    reputation: float
+    users: float
+    market_share: float
+
+    def to_dict(self) -> StatDict:
+        """Serialize stats into a dictionary."""
+
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: StatDict) -> "GameStats":
+        """Create stats from a dictionary."""
+
+        return cls(
+            balance=float(data["balance"]),
+            revenue=float(data["revenue"]),
+            expenses=float(data["expenses"]),
+            product_level=int(data["product_level"]),
+            bug_rate=float(data["bug_rate"]),
+            team_size=int(data["team_size"]),
+            morale=float(data["morale"]),
+            productivity=float(data["productivity"]),
+            reputation=float(data["reputation"]),
+            users=float(data["users"]),
+            market_share=float(data["market_share"]),
+        )
+
+
+@dataclass
+class GameState:
+    """Represents the full game state."""
+
+    stats: GameStats
+    turn: int
+    active_events: List[ActiveEvent] = field(default_factory=list)
+    last_report: List[str] = field(default_factory=list)
+    rng_state: Optional[Tuple[int, Tuple[int, ...], Optional[int]]] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        """Serialize the game state to a JSON-compatible dictionary."""
+
+        return {
+            "stats": self.stats.to_dict(),
+            "turn": self.turn,
+            "active_events": [
+                {
+                    "event_id": active.event.event_id,
+                    "remaining_turns": active.remaining_turns,
+                }
+                for active in self.active_events
+            ],
+            "last_report": self.last_report,
+            "rng_state": self._serialize_rng_state(),
+        }
+
+    def _serialize_rng_state(self) -> Optional[Dict[str, object]]:
+        if self.rng_state is None:
+            return None
+        version, state, gauss = self.rng_state
+        return {
+            "version": version,
+            "state": list(state),
+            "gauss": gauss,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Dict[str, object],
+        events_by_id: Dict[str, Event],
+    ) -> "GameState":
+        """Deserialize a game state from a dictionary."""
+
+        stats = GameStats.from_dict(data["stats"])  # type: ignore[index]
+        active_events: List[ActiveEvent] = []
+        for entry in data.get("active_events", []):  # type: ignore[arg-type]
+            event_id = entry["event_id"]
+            remaining = int(entry["remaining_turns"])
+            event = events_by_id.get(event_id)
+            if event:
+                active_events.append(ActiveEvent(event=event, remaining_turns=remaining))
+        rng_state = cls._deserialize_rng_state(data.get("rng_state"))
+        return cls(
+            stats=stats,
+            turn=int(data["turn"]),
+            active_events=active_events,
+            last_report=list(data.get("last_report", [])),
+            rng_state=rng_state,
+        )
+
+    @staticmethod
+    def _deserialize_rng_state(data: Optional[Dict[str, object]]) -> Optional[Tuple[int, Tuple[int, ...], Optional[int]]]:
+        if not data:
+            return None
+        version = int(data["version"])
+        state = tuple(int(value) for value in data["state"])  # type: ignore[index]
+        gauss_value = data.get("gauss")
+        gauss = int(gauss_value) if gauss_value is not None else None
+        return (version, state, gauss)
+
+
+SCHEMA_VERSION = "1.0"
+
+
+def default_rng(seed: Optional[int] = None) -> random.Random:
+    """Create a deterministic random generator."""
+
+    rng = random.Random()
+    if seed is not None:
+        rng.seed(seed)
+    return rng

--- a/startup_simulator/utils.py
+++ b/startup_simulator/utils.py
@@ -1,0 +1,53 @@
+"""Utility functions for Startup Simulator."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+from textwrap import fill
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp a numeric value between minimum and maximum."""
+
+    return max(minimum, min(value, maximum))
+
+
+def format_currency(value: float) -> str:
+    """Format currency values for display."""
+
+    return f"${value:,.0f}"
+
+
+def format_percentage(value: float) -> str:
+    """Format percentage values for display."""
+
+    return f"{value:.1f}%"
+
+
+def wrap_text(text: str, width: int = 70) -> str:
+    """Wrap narrative text for terminal display."""
+
+    return fill(text, width=width)
+
+
+def join_and(items: Iterable[str]) -> str:
+    """Join items with commas and an 'and'."""
+
+    items_list = list(items)
+    if not items_list:
+        return ""
+    if len(items_list) == 1:
+        return items_list[0]
+    return ", ".join(items_list[:-1]) + f" and {items_list[-1]}"
+
+
+def parse_int(value: str) -> Optional[int]:
+    """Parse an integer from a string if possible."""
+
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None


### PR DESCRIPTION
## Summary
- add CLI entry point and supporting package for the Startup Simulator gameplay loop
- seed the project with JSON data describing events, actions, and starting profiles
- document game usage and flow in the README

## Testing
- python -m compileall startup_simulator

------
https://chatgpt.com/codex/tasks/task_b_68e28a6c66508327a0399ebc901a0138