### PR TITLE
Implement action registry with stochastic resolution

### DIFF
--- a/startup_simulator/actions.py
+++ b/startup_simulator/actions.py
@@ -1,37 +1,280 @@
 """Definitions and utilities for player actions."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Any, Dict
 
 import json
+import random
 
 from . import config
+from .startup import Startup
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class Action:
     """Represents an actionable decision a player can take during a turn."""
 
-    key: str
+    id: str
     name: str
-    description: str
-    cost: float
-    impact: Dict[str, float]
+    costs: Mapping[str, float] = field(default_factory=dict)
+    effects: Mapping[str, float] = field(default_factory=dict)
+    risk: Mapping[str, Any] | None = None
+    narrative: str = ""
+    max_per_turn: int | None = None
 
 
-def load_actions(data_path: Path | None = None) -> List[Action]:
-    """Load available actions from the JSON definition file."""
-    path = data_path or (config.DATA_DIRECTORY / "actions.json")
+def _coerce_action(data: Mapping[str, Any]) -> Action:
+    """Coerce raw dictionary data into an :class:`Action` instance."""
+
+    action_id = data.get("id") or data.get("key")
+    if not action_id:
+        raise KeyError("Action definition missing required 'id' field.")
+    name = data.get("name") or action_id.replace("_", " ").title()
+
+    narrative = data.get("narrative") or data.get("description") or ""
+
+    costs: Mapping[str, float]
+    if "costs" in data and isinstance(data["costs"], Mapping):
+        costs = dict(data["costs"])
+    elif "cost" in data:
+        # Legacy single-cost field assumed to target the balance attribute.
+        costs = {"balance": float(data["cost"]) }
+    else:
+        costs = {}
+
+    effects: Mapping[str, float]
+    if "effects" in data and isinstance(data["effects"], Mapping):
+        effects = dict(data["effects"])
+    elif "impact" in data and isinstance(data["impact"], Mapping):
+        effects = dict(data["impact"])
+    else:
+        effects = {}
+
+    risk = data.get("risk") if isinstance(data.get("risk"), Mapping) else None
+
+    max_per_turn = data.get("max_per_turn")
+    if max_per_turn is not None:
+        max_per_turn = int(max_per_turn)
+
+    return Action(
+        id=str(action_id),
+        name=str(name),
+        costs=costs,
+        effects=effects,
+        risk=risk,
+        narrative=str(narrative),
+        max_per_turn=max_per_turn,
+    )
+
+
+def _load_from_json(path: Path) -> Dict[str, Action]:
+    """Load actions from the provided JSON path."""
+
     with path.open("r", encoding="utf-8") as handle:
         raw_actions = json.load(handle)
-    return [Action(**item) for item in raw_actions]
+
+    if not isinstance(raw_actions, Iterable):
+        raise ValueError("Actions JSON must contain a list of action definitions.")
+
+    actions: Dict[str, Action] = {}
+    for entry in raw_actions:
+        if not isinstance(entry, Mapping):
+            raise ValueError("Each action definition must be a JSON object.")
+        action = _coerce_action(entry)
+        actions[action.id] = action
+    return actions
 
 
-def action_keys(actions: Iterable[Action]) -> List[str]:
-    """Return a list of action keys for quick membership tests."""
-    return [action.key for action in actions]
+def _fallback_actions() -> Dict[str, Action]:
+    """Return an in-code fallback registry of actions."""
+
+    default_actions = [
+        Action(
+            id="ship_feature",
+            name="Ship Major Feature",
+            narrative="The team rushes to ship a headline feature.",
+            costs={"balance": 25000, "team_morale": 3},
+            effects={"product_quality": 8.0, "users": 400},
+            risk={
+                "success_chance": 0.8,
+                "success": {
+                    "effects": {"brand_awareness": 6.0},
+                    "narrative": "Users love the polish and word of mouth spreads.",
+                },
+                "failure": {
+                    "effects": {"team_morale": -5.0},
+                    "narrative": "Unexpected bugs force an emergency rollback.",
+                },
+            },
+            max_per_turn=1,
+        ),
+        Action(
+            id="marketing_blast",
+            name="Launch Marketing Campaign",
+            narrative="You greenlight a week-long marketing blitz.",
+            costs={"balance": 18000},
+            effects={"brand_awareness": 12.0, "users": 600},
+            risk={
+                "success_chance": 0.65,
+                "success": {
+                    "effects": {"monthly_revenue": 8000},
+                    "narrative": "The campaign resonates and signups climb.",
+                },
+                "failure": {
+                    "effects": {"brand_awareness": -4.0},
+                    "narrative": "The message misses the mark and social media piles on.",
+                },
+            },
+            max_per_turn=2,
+        ),
+        Action(
+            id="investor_pitch",
+            name="Pitch to Investors",
+            narrative="You polish the deck and pitch to a room of VCs.",
+            costs={"balance": 7000},
+            effects={},
+            risk={
+                "success_chance": 0.45,
+                "success": {
+                    "effects": {"balance": 220000, "brand_awareness": 8.0},
+                    "narrative": "Investors are impressed and wire a new round of funding.",
+                },
+                "failure": {
+                    "effects": {"team_morale": -6.0, "brand_awareness": -3.0},
+                    "narrative": "The questions get hostile and word spreads of the shaky pitch.",
+                },
+            },
+            max_per_turn=1,
+        ),
+    ]
+
+    return {action.id: action for action in default_actions}
 
 
-__all__ = ["Action", "load_actions", "action_keys"]
+def load_actions(data_path: Path | None = None) -> Dict[str, Action]:
+    """Load available actions, falling back to defaults if necessary."""
+
+    path = data_path or (config.DATA_DIRECTORY / "actions.json")
+    try:
+        return _load_from_json(path)
+    except FileNotFoundError:
+        return _fallback_actions()
+
+
+ACTION_REGISTRY: Dict[str, Action] = load_actions()
+
+
+def _affordable(startup: Startup, action: Action) -> bool:
+    """Return whether the startup can currently afford the action."""
+
+    balance_cost = action.costs.get("balance")
+    if balance_cost is not None and startup.balance < balance_cost:
+        return False
+    return True
+
+
+def list_actions(startup: Startup) -> list[Action]:
+    """Return the list of actions available to the provided startup state."""
+
+    available = [action for action in ACTION_REGISTRY.values() if _affordable(startup, action)]
+    return sorted(available, key=lambda item: item.name)
+
+
+def _clamp_turn_limit(limit: int | None) -> int:
+    if limit is None:
+        limit = config.MAX_ACTIONS_PER_TURN
+    return max(1, min(3, limit))
+
+
+def validate_action_limit(
+    actions_taken: Mapping[str, int],
+    action: Action,
+    max_actions: int | None = None,
+) -> None:
+    """Validate whether another instance of *action* can be taken this turn.
+
+    Raises a :class:`ValueError` if a limit is exceeded.
+    """
+
+    limit = _clamp_turn_limit(max_actions)
+    total_taken = sum(actions_taken.values())
+    if total_taken >= limit:
+        raise ValueError(f"A maximum of {limit} actions may be taken per turn.")
+
+    per_action_limit = action.max_per_turn
+    if per_action_limit is not None:
+        already_taken = actions_taken.get(action.id, 0)
+        if already_taken >= per_action_limit:
+            raise ValueError(
+                f"Action '{action.name}' can only be taken {per_action_limit} time(s) per turn."
+            )
+
+
+def _apply_deltas(startup: Startup, deltas: Mapping[str, float]) -> None:
+    numeric_deltas: Dict[str, float] = {}
+    for key, delta in deltas.items():
+        if not hasattr(startup, key):
+            raise ValueError(f"Action references unknown startup attribute '{key}'.")
+        numeric_deltas[key] = float(delta)
+    if numeric_deltas:
+        startup.apply_deltas(numeric_deltas)
+
+
+def _apply_costs(startup: Startup, action: Action) -> None:
+    if not action.costs:
+        return
+    balance_cost = action.costs.get("balance")
+    if balance_cost is not None and startup.balance < balance_cost:
+        raise ValueError(
+            f"Insufficient balance to perform action '{action.name}'. Required {balance_cost}, have {startup.balance}."
+        )
+    deltas = {key: -value for key, value in action.costs.items()}
+    _apply_deltas(startup, deltas)
+
+
+def apply_action(startup: Startup, action_id: str, rng: random.Random) -> tuple[Startup, str]:
+    """Apply *action_id* to *startup* using the provided RNG for stochastic outcomes."""
+
+    if action_id not in ACTION_REGISTRY:
+        raise ValueError(f"Unknown action id: {action_id}")
+
+    action = ACTION_REGISTRY[action_id]
+    narrative_parts = [action.narrative.strip()] if action.narrative else []
+
+    _apply_costs(startup, action)
+    _apply_deltas(startup, action.effects)
+
+    outcome_text: str | None = None
+    if action.risk:
+        success_chance = float(action.risk.get("success_chance", 0.0))
+        roll = rng.random()
+        branch_key = "success" if roll < success_chance else "failure"
+        branch = action.risk.get(branch_key)
+        if isinstance(branch, Mapping):
+            branch_effects = branch.get("effects")
+            if isinstance(branch_effects, Mapping):
+                _apply_deltas(startup, branch_effects)
+            outcome_text = str(branch.get("narrative")) if branch.get("narrative") else None
+        else:
+            outcome_text = None
+
+    if outcome_text:
+        narrative_parts.append(outcome_text.strip())
+
+    startup.clamp_all()
+
+    final_narrative = " ".join(part for part in narrative_parts if part)
+    return startup, final_narrative
+
+
+__all__ = [
+    "Action",
+    "ACTION_REGISTRY",
+    "apply_action",
+    "list_actions",
+    "load_actions",
+    "validate_action_limit",
+]

--- a/startup_simulator/data/actions.json
+++ b/startup_simulator/data/actions.json
@@ -1,23 +1,59 @@
 [
   {
-    "key": "networking_event",
-    "name": "Attend Networking Event",
-    "description": "Meet potential investors and partners at a local meetup.",
-    "cost": 500.0,
-    "impact": {"morale": 5.0, "brand": 8.0}
-  },
-  {
-    "key": "ship_feature",
+    "id": "ship_feature",
     "name": "Ship Major Feature",
-    "description": "Release a highly anticipated feature to users.",
-    "cost": 25000.0,
-    "impact": {"product": 12.0, "morale": -3.0}
+    "narrative": "The roadmap finally reaches a major milestone.",
+    "costs": {"balance": 22000, "team_morale": 2},
+    "effects": {"product_quality": 9.0, "users": 350},
+    "risk": {
+      "success_chance": 0.75,
+      "success": {
+        "effects": {"brand_awareness": 5.0},
+        "narrative": "Press coverage highlights the quality of the release."
+      },
+      "failure": {
+        "effects": {"team_morale": -4.0},
+        "narrative": "A post-launch outage forces an exhausting hotfix sprint."
+      }
+    },
+    "max_per_turn": 1
   },
   {
-    "key": "optimize_infra",
-    "name": "Optimize Infrastructure",
-    "description": "Reduce hosting costs through infrastructure improvements.",
-    "cost": 10000.0,
-    "impact": {"finance": 10.0}
+    "id": "marketing_blast",
+    "name": "Launch Marketing Campaign",
+    "narrative": "Fresh creative goes live across every channel.",
+    "costs": {"balance": 16000},
+    "effects": {"brand_awareness": 14.0, "users": 500},
+    "risk": {
+      "success_chance": 0.6,
+      "success": {
+        "effects": {"monthly_revenue": 6000},
+        "narrative": "Conversion rates spike as audiences respond enthusiastically."
+      },
+      "failure": {
+        "effects": {"brand_awareness": -5.0},
+        "narrative": "The messaging misses and the internet shrugs."
+      }
+    },
+    "max_per_turn": 2
+  },
+  {
+    "id": "investor_pitch",
+    "name": "Pitch to Investors",
+    "narrative": "You schedule back-to-back meetings with prominent funds.",
+    "costs": {"balance": 6000},
+    "effects": {},
+    "risk": {
+      "success_chance": 0.4,
+      "success": {
+        "effects": {"balance": 200000, "brand_awareness": 7.0},
+        "narrative": "Investors wire a term sheet before you leave the room."
+      },
+      "failure": {
+        "effects": {"team_morale": -5.0, "brand_awareness": -2.0},
+        "narrative": "The feedback is brutal and rumours circulate online."
+      }
+    },
+    "max_per_turn": 1
   }
 ]

--- a/startup_simulator/main.py
+++ b/startup_simulator/main.py
@@ -12,9 +12,9 @@ if __package__ in {None, ""}:  # pragma: no cover - convenience for script execu
     package_root = Path(__file__).resolve().parent.parent
     if str(package_root) not in sys.path:
         sys.path.insert(0, str(package_root))
-    from startup_simulator import actions, config, events, player, save_system, ui_text
+    from startup_simulator import actions, config, events, player, save_system, startup, ui_text
 else:  # pragma: no cover
-    from . import actions, config, events, player, save_system, ui_text
+    from . import actions, config, events, player, save_system, startup, ui_text
 
 
 def parse_args() -> argparse.Namespace:
@@ -53,7 +53,8 @@ def run() -> None:
     profile = load_startup_profile()
     state = initialise_player(profile)
 
-    available_actions = actions.load_actions()
+    dummy_startup = startup.Startup()
+    available_actions = actions.list_actions(dummy_startup)
     available_events = events.load_events()
 
     print(f"Loaded profile: {state.name}")

--- a/startup_simulator/tests/test_actions.py
+++ b/startup_simulator/tests/test_actions.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from startup_simulator import actions
+from startup_simulator.startup import Startup
+
+
+def test_list_actions_filters_unaffordable(monkeypatch):
+    affordable = actions.Action(
+        id="affordable",
+        name="Affordable",
+        narrative="",
+        costs={"balance": 1_000},
+        effects={},
+    )
+    pricey = actions.Action(
+        id="pricey",
+        name="Pricey",
+        narrative="",
+        costs={"balance": 10_000},
+        effects={},
+    )
+    registry = {action.id: action for action in (affordable, pricey)}
+    monkeypatch.setattr(actions, "ACTION_REGISTRY", registry)
+
+    available = actions.list_actions(Startup(balance=5_000))
+    assert [action.name for action in available] == ["Affordable"]
+
+
+def test_apply_action_deducts_cost_and_clamps(monkeypatch):
+    action = actions.Action(
+        id="clamp_test",
+        name="Clamp Test",
+        narrative="Testing narrative.",
+        costs={"balance": 500},
+        effects={"product_quality": 150.0},
+    )
+    monkeypatch.setattr(actions, "ACTION_REGISTRY", {action.id: action})
+
+    state = Startup(balance=1_000, product_quality=80.0)
+    updated, narrative = actions.apply_action(state, "clamp_test", random.Random(1))
+
+    assert updated.balance == 500
+    assert updated.product_quality == 100.0
+    assert narrative == "Testing narrative."
+
+
+def test_apply_action_handles_risk_success(monkeypatch):
+    risky = actions.Action(
+        id="risky",
+        name="Risky",
+        narrative="Taking a risk.",
+        costs={},
+        effects={"brand_awareness": 1.0},
+        risk={
+            "success_chance": 0.9,
+            "success": {
+                "effects": {"balance": 5_000},
+                "narrative": "It works!",
+            },
+            "failure": {
+                "effects": {"team_morale": -10.0},
+                "narrative": "It fails.",
+            },
+        },
+    )
+    monkeypatch.setattr(actions, "ACTION_REGISTRY", {risky.id: risky})
+
+    state = Startup(balance=100)
+    rng = random.Random(1)  # ensures success because 0.134 < 0.9
+    updated, narrative = actions.apply_action(state, "risky", rng)
+
+    assert updated.balance == 5_100
+    assert updated.brand_awareness > 1.0
+    assert "It works!" in narrative
+
+
+def test_apply_action_handles_risk_failure(monkeypatch):
+    risky = actions.Action(
+        id="risky_fail",
+        name="Risky Fail",
+        narrative="Attempting something bold.",
+        costs={},
+        effects={},
+        risk={
+            "success_chance": 0.0,
+            "success": {
+                "effects": {"balance": 5_000},
+            },
+            "failure": {
+                "effects": {"team_morale": -5.0},
+                "narrative": "It fails badly.",
+            },
+        },
+    )
+    monkeypatch.setattr(actions, "ACTION_REGISTRY", {risky.id: risky})
+
+    state = Startup(team_morale=50.0)
+    updated, narrative = actions.apply_action(state, "risky_fail", random.Random(5))
+
+    assert updated.team_morale == 45.0
+    assert narrative.endswith("It fails badly.")
+
+
+def test_unknown_action_raises():
+    with pytest.raises(ValueError, match="Unknown action id: does_not_exist"):
+        actions.apply_action(Startup(), "does_not_exist", random.Random(0))
+
+
+def test_validate_action_limit(monkeypatch):
+    limited = actions.Action(
+        id="limited",
+        name="Limited",
+        narrative="",
+        costs={},
+        effects={},
+        max_per_turn=1,
+    )
+    monkeypatch.setattr(actions, "ACTION_REGISTRY", {limited.id: limited})
+
+    actions.validate_action_limit({"limited": 0}, limited)
+
+    with pytest.raises(ValueError):
+        actions.validate_action_limit({"limited": 1}, limited)
+
+    with pytest.raises(ValueError):
+        actions.validate_action_limit({"limited": 0, "other": 3}, limited, max_actions=1)


### PR DESCRIPTION
## Summary
- replace the action model with a structured dataclass backed by a JSON registry and fallback defaults
- implement helpers to list available actions, enforce per-turn limits, and apply costs/effects with RNG-driven risk outcomes
- update the CLI to surface filtered actions and add tests covering affordability filtering, clamping, and risk branches

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68e296607f8c8327b03c8cf2c250e27f