### PR TITLE
Implement robust save system with schema validation

### DIFF
--- a/startup_simulator/save_system.py
+++ b/startup_simulator/save_system.py
@@ -1,34 +1,95 @@
 """Simple save and load utilities for the simulator."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Mapping
 
 from . import config
+from .startup import Startup
 
 
-def save_state(state: Dict[str, Any], path: Path | None = None) -> None:
-    """Persist the simulation state to disk."""
-    save_path = path or Path(config.AUTOSAVE_FILENAME)
-    payload = {
-        "schema_version": config.SAVE_SCHEMA_VERSION,
-        "state": state,
+SCHEMA_VERSION: str = getattr(config, "SAVE_SCHEMA_VERSION", "1.0")
+SAVE_PATH: Path = Path(getattr(config, "AUTOSAVE_FILENAME", "save.json"))
+_REQUIRED_KEYS: tuple[str, ...] = ("version", "timestamp", "turn", "rng_seed", "startup")
+
+
+def _current_timestamp() -> str:
+    """Return a timezone-aware ISO8601 timestamp."""
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def validate_snapshot(data: Mapping[str, Any] | None) -> bool:
+    """Validate the structure and schema version of a save snapshot."""
+
+    if not isinstance(data, Mapping):
+        return False
+    if any(key not in data for key in _REQUIRED_KEYS):
+        return False
+    if data.get("version") != SCHEMA_VERSION:
+        return False
+    timestamp = data.get("timestamp")
+    if not isinstance(timestamp, str):
+        return False
+    try:
+        datetime.fromisoformat(timestamp)
+    except ValueError:
+        return False
+    try:
+        int(data.get("turn"))
+        int(data.get("rng_seed"))
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(data.get("startup"), Mapping):
+        return False
+    return True
+
+
+def save_game(startup: Startup, path: Path | None = None) -> None:
+    """Persist a :class:`Startup` instance to disk."""
+
+    save_path = path or SAVE_PATH
+    snapshot = {
+        "version": SCHEMA_VERSION,
+        "timestamp": _current_timestamp(),
+        "turn": int(startup.turn),
+        "rng_seed": int(startup.rng_seed),
+        "startup": startup.snapshot(),
     }
-    with save_path.open("w", encoding="utf-8") as handle:
-        json.dump(payload, handle, indent=2)
+    try:
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        with save_path.open("w", encoding="utf-8") as handle:
+            json.dump(snapshot, handle, indent=2)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Failed to save game: {exc}")
 
 
-def load_state(path: Path | None = None) -> Dict[str, Any] | None:
-    """Load the simulation state from disk if available."""
-    save_path = path or Path(config.AUTOSAVE_FILENAME)
-    if not save_path.exists():
+def load_game(path: Path | None = None) -> Startup | None:
+    """Load a saved :class:`Startup` instance from disk."""
+
+    save_path = path or SAVE_PATH
+    try:
+        if not save_path.exists():
+            return None
+        with save_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Failed to load game: {exc}")
         return None
-    with save_path.open("r", encoding="utf-8") as handle:
-        payload = json.load(handle)
-    if payload.get("schema_version") != config.SAVE_SCHEMA_VERSION:
-        raise ValueError("Save file schema version mismatch.")
-    return payload.get("state")
+    if not validate_snapshot(data):
+        print("Save file is invalid or incompatible.")
+        return None
+    try:
+        startup_data = data["startup"]
+        startup = Startup.from_snapshot(startup_data)
+        startup.turn = int(data["turn"])
+        startup.rng_seed = int(data["rng_seed"])
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"Failed to restore game state: {exc}")
+        return None
+    return startup
 
 
-__all__ = ["save_state", "load_state"]
+__all__ = ["SAVE_PATH", "save_game", "load_game", "validate_snapshot"]

--- a/startup_simulator/tests/test_save.py
+++ b/startup_simulator/tests/test_save.py
@@ -1,19 +1,48 @@
 """Tests for the save system."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
+import json
 from pathlib import Path
 
+import pytest
+
 from startup_simulator import save_system
+from startup_simulator.startup import Startup
 
 
-def test_save_and_load_roundtrip(tmp_path: Path) -> None:
-    save_file = tmp_path / "save.json"
-    state = {"player": "Alex", "month": 3}
-    save_system.save_state(state, save_file)
-    loaded = save_system.load_state(save_file)
-    assert loaded == state
+@pytest.fixture(autouse=True)
+def override_save_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "save.json"
+    monkeypatch.setattr(save_system, "SAVE_PATH", path)
+    return path
 
 
-def test_load_state_missing_file(tmp_path: Path) -> None:
-    save_file = tmp_path / "missing.json"
-    assert save_system.load_state(save_file) is None
+def test_save_and_load_roundtrip() -> None:
+    startup = Startup(balance=750_000, turn=5, rng_seed=99)
+    startup.active_events.append("launch_party")
+    save_system.save_game(startup)
+    loaded = save_system.load_game()
+    assert loaded is not None
+    assert loaded.snapshot() == startup.snapshot()
+
+
+def test_load_game_missing_file() -> None:
+    assert save_system.load_game() is None
+
+
+def test_load_game_with_corrupted_file(override_save_path: Path) -> None:
+    override_save_path.write_text("{not valid json}", encoding="utf-8")
+    assert save_system.load_game() is None
+
+
+def test_load_game_with_schema_mismatch(override_save_path: Path) -> None:
+    payload = {
+        "version": "0.0",  # incorrect schema version
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "turn": 1,
+        "rng_seed": 42,
+        "startup": Startup().snapshot(),
+    }
+    override_save_path.write_text(json.dumps(payload), encoding="utf-8")
+    assert save_system.load_game() is None


### PR DESCRIPTION
## Summary
- add schema-aware save and load helpers that capture startup snapshots with timestamps and RNG seed
- validate saved snapshots before loading and gracefully handle IO or schema errors
- update save system tests to cover round-trip, missing files, corruption, and schema mismatches

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e32ee294c88327bfb6faf4c9dfc1e6