### PR TITLE
Expand seed data for actions, events, and profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Startup Simulator is a lightweight command-line prototype that simulates the ear
 
 Running the CLI prints a banner, loads the default startup profile, and lists the available actions and random events defined in `startup_simulator/data`. This scaffold is a starting point for further gameplay logic such as processing turns, applying actions, and resolving events.
 
+## Seed Data
+
+The `/startup_simulator/data` directory provides JSON seeds that power the simulation:
+
+- `actions.json` contains a balanced set of 10+ actions with modest costs, effects, and risks so the early game remains stable.
+- `events.json` enumerates 10+ random events with varied durations and reversible effects to keep runs dynamic without runaway swings.
+- `startup_profiles.json` lists curated starting profiles (Lean FinTech, Growth Hacker, and Enterprise B2B) that override portions of the default stats.
+
+These files are regular JSON and intentionally omit inline comments so they can be loaded directly by the Python modules.
+
 ## How to Test
 
 The project includes a small test suite using `pytest`.

--- a/startup_simulator/data/actions.json
+++ b/startup_simulator/data/actions.json
@@ -4,7 +4,7 @@
     "name": "Ship Major Feature",
     "narrative": "The roadmap finally reaches a major milestone.",
     "costs": {"balance": 22000, "team_morale": 2},
-    "effects": {"product_quality": 9.0, "users": 350},
+    "effects": {"product_quality": 9.0, "users": 320},
     "risk": {
       "success_chance": 0.75,
       "success": {
@@ -22,16 +22,16 @@
     "id": "marketing_blast",
     "name": "Launch Marketing Campaign",
     "narrative": "Fresh creative goes live across every channel.",
-    "costs": {"balance": 16000},
-    "effects": {"brand_awareness": 14.0, "users": 500},
+    "costs": {"balance": 15000},
+    "effects": {"brand_awareness": 12.0, "users": 450},
     "risk": {
       "success_chance": 0.6,
       "success": {
-        "effects": {"monthly_revenue": 6000},
+        "effects": {"monthly_revenue": 5000},
         "narrative": "Conversion rates spike as audiences respond enthusiastically."
       },
       "failure": {
-        "effects": {"brand_awareness": -5.0},
+        "effects": {"brand_awareness": -4.0},
         "narrative": "The messaging misses and the internet shrugs."
       }
     },
@@ -44,14 +44,114 @@
     "costs": {"balance": 6000},
     "effects": {},
     "risk": {
-      "success_chance": 0.4,
+      "success_chance": 0.35,
       "success": {
-        "effects": {"balance": 200000, "brand_awareness": 7.0},
+        "effects": {"balance": 150000, "brand_awareness": 6.0},
         "narrative": "Investors wire a term sheet before you leave the room."
       },
       "failure": {
-        "effects": {"team_morale": -5.0, "brand_awareness": -2.0},
+        "effects": {"team_morale": -4.0, "brand_awareness": -1.0},
         "narrative": "The feedback is brutal and rumours circulate online."
+      }
+    },
+    "max_per_turn": 1
+  },
+  {
+    "id": "user_research_sprint",
+    "name": "Run User Research Sprint",
+    "narrative": "Researchers dig into interviews and usability tests for fresh insights.",
+    "costs": {"balance": 5000},
+    "effects": {"product_quality": 4.0, "churn_rate": -0.005, "team_morale": 2.0},
+    "max_per_turn": 1
+  },
+  {
+    "id": "build_referral_program",
+    "name": "Build Referral Program",
+    "narrative": "You launch incentives to encourage organic invites.",
+    "costs": {"balance": 7000},
+    "effects": {"users": 220, "growth_rate": 0.01, "brand_awareness": 3.0},
+    "risk": {
+      "success_chance": 0.55,
+      "success": {
+        "effects": {"monthly_revenue": 3000},
+        "narrative": "Early adopters share their invite codes broadly."
+      },
+      "failure": {
+        "effects": {"churn_rate": 0.004},
+        "narrative": "Rewards confuse users and some drift away."
+      }
+    },
+    "max_per_turn": 1
+  },
+  {
+    "id": "optimize_infrastructure",
+    "name": "Optimize Infrastructure",
+    "narrative": "Engineers refactor critical services to lower hosting costs.",
+    "costs": {"balance": 9000},
+    "effects": {"product_quality": 3.0, "monthly_expenses": -4000},
+    "risk": {
+      "success_chance": 0.7,
+      "success": {
+        "effects": {"balance": 2000},
+        "narrative": "Performance improvements drop the cloud bill immediately."
+      },
+      "failure": {
+        "effects": {"product_quality": -2.0, "monthly_expenses": 2000},
+        "narrative": "An unexpected regression forces you to overprovision servers."
+      }
+    },
+    "max_per_turn": 1
+  },
+  {
+    "id": "host_community_event",
+    "name": "Host Community Event",
+    "narrative": "You bring power users together for demos, feedback, and camaraderie.",
+    "costs": {"balance": 4500},
+    "effects": {"brand_awareness": 5.0, "users": 120, "team_morale": 3.0},
+    "max_per_turn": 2
+  },
+  {
+    "id": "renegotiate_vendors",
+    "name": "Renegotiate Vendor Contracts",
+    "narrative": "Finance digs into vendor relationships searching for savings.",
+    "costs": {"team_morale": 3.0},
+    "effects": {"monthly_expenses": -6000, "debt": -5000},
+    "max_per_turn": 1
+  },
+  {
+    "id": "restructure_pricing",
+    "name": "Experiment with Pricing",
+    "narrative": "You A/B test a new pricing tier for your product.",
+    "costs": {},
+    "effects": {},
+    "risk": {
+      "success_chance": 0.5,
+      "success": {
+        "effects": {"monthly_revenue": 7000, "churn_rate": -0.004},
+        "narrative": "Customers adopt the new tier and churn drops."
+      },
+      "failure": {
+        "effects": {"monthly_revenue": -4000, "brand_awareness": -3.0},
+        "narrative": "Pricing confusion sparks frustration on social media."
+      }
+    },
+    "max_per_turn": 1
+  },
+  {
+    "id": "hire_growth_lead",
+    "name": "Hire Growth Lead",
+    "narrative": "You recruit a specialist to focus on onboarding and funnels.",
+    "costs": {"balance": 12000},
+    "effects": {"monthly_expenses": 6000, "brand_awareness": 4.0, "growth_rate": 0.015},
+    "risk": {
+      "success_chance": 0.65,
+      "success": {
+        "effects": {"team_morale": 2.0},
+        "narrative": "The new hire lifts energy across product and marketing."
+      },
+      "failure": {
+        "effects": {"team_morale": -3.0},
+        "narrative": "The hire struggles to ramp and frustrates the team."
       }
     },
     "max_per_turn": 1

--- a/startup_simulator/data/events.json
+++ b/startup_simulator/data/events.json
@@ -1,16 +1,90 @@
 [
   {
-    "key": "press_coverage",
-    "name": "Positive Press Coverage",
-    "description": "A major tech blog features the startup.",
-    "probability": 0.2,
-    "impact": {"brand": 15.0, "product": 5.0}
+    "id": "app_store_feature",
+    "name": "App Store Feature",
+    "narrative": "A platform partner highlights your product in a curated collection.",
+    "trigger_chance": 0.08,
+    "duration_turns": 2,
+    "effects": {"brand_awareness": 9.0, "users": 280, "monthly_revenue": 4000}
   },
   {
-    "key": "service_outage",
-    "name": "Service Outage",
-    "description": "An unexpected outage affects user trust.",
-    "probability": 0.15,
-    "impact": {"brand": -10.0, "morale": -12.0}
+    "id": "cloud_credit_grant",
+    "name": "Cloud Credit Grant",
+    "narrative": "Your infrastructure provider awards a grant of platform credits.",
+    "trigger_chance": 0.1,
+    "duration_turns": 3,
+    "effects": {"balance": 20000, "monthly_expenses": -5000}
+  },
+  {
+    "id": "competitor_feature_parity",
+    "name": "Competitor Ships Feature Parity",
+    "narrative": "A rival launches a clone of your flagship functionality.",
+    "trigger_chance": 0.14,
+    "duration_turns": 2,
+    "effects": {"brand_awareness": -5.0, "product_quality": -3.0}
+  },
+  {
+    "id": "customer_advocacy_wave",
+    "name": "Customer Advocacy Wave",
+    "narrative": "Power users rave about you in forums and review sites.",
+    "trigger_chance": 0.09,
+    "duration_turns": 2,
+    "effects": {"churn_rate": -0.008, "brand_awareness": 6.0, "team_morale": 3.0}
+  },
+  {
+    "id": "data_breach",
+    "name": "Minor Data Breach",
+    "narrative": "An incident exposes a limited subset of user data before being contained.",
+    "trigger_chance": 0.07,
+    "duration_turns": 3,
+    "effects": {"brand_awareness": -12.0, "users": -180, "churn_rate": 0.02}
+  },
+  {
+    "id": "growth_award",
+    "name": "Industry Growth Award",
+    "narrative": "Analysts recognise your momentum with a niche award.",
+    "trigger_chance": 0.06,
+    "duration_turns": 1,
+    "effects": {"brand_awareness": 8.0, "monthly_revenue": 5000}
+  },
+  {
+    "id": "hiring_frenzy",
+    "name": "Hiring Frenzy",
+    "narrative": "A wave of strong candidates accept offers all at once.",
+    "trigger_chance": 0.08,
+    "duration_turns": 3,
+    "effects": {"headcount": 3, "monthly_expenses": 9000, "team_morale": 2.0}
+  },
+  {
+    "id": "infrastructure_glitch",
+    "name": "Infrastructure Glitch",
+    "narrative": "A finicky dependency causes intermittent downtime for some customers.",
+    "trigger_chance": 0.11,
+    "duration_turns": 2,
+    "effects": {"product_quality": -4.0, "monthly_revenue": -5000, "team_morale": -3.0}
+  },
+  {
+    "id": "press_spotlight",
+    "name": "Press Spotlight",
+    "narrative": "A prominent tech journalist publishes a glowing feature article.",
+    "trigger_chance": 0.15,
+    "duration_turns": 1,
+    "effects": {"brand_awareness": 10.0, "users": 320}
+  },
+  {
+    "id": "regulatory_audit",
+    "name": "Regulatory Audit",
+    "narrative": "Regulators request documentation, slowing several projects.",
+    "trigger_chance": 0.05,
+    "duration_turns": 2,
+    "effects": {"balance": -15000, "product_quality": -2.0, "team_morale": -2.0}
+  },
+  {
+    "id": "support_ticket_surge",
+    "name": "Support Ticket Surge",
+    "narrative": "A flurry of customer issues floods the support queue.",
+    "trigger_chance": 0.12,
+    "duration_turns": 2,
+    "effects": {"team_morale": -5.0, "product_quality": -2.0, "churn_rate": 0.01}
   }
 ]

--- a/startup_simulator/data/startup_profiles.json
+++ b/startup_simulator/data/startup_profiles.json
@@ -1,10 +1,50 @@
 [
   {
-    "name": "Nimbus Analytics",
+    "name": "Lean FinTech",
+    "description": "Bootstrap-minded financial tools team with disciplined spending.",
     "metrics": {
-      "morale": 70,
-      "product": 60,
-      "brand": 40
+      "balance": 350000,
+      "monthly_revenue": 38000,
+      "monthly_expenses": 70000,
+      "users": 1200,
+      "growth_rate": 0.09,
+      "churn_rate": 0.035,
+      "product_quality": 58.0,
+      "brand_awareness": 45.0,
+      "team_morale": 72.0,
+      "headcount": 14
+    }
+  },
+  {
+    "name": "Growth Hacker",
+    "description": "Scrappy consumer app chasing aggressive top-line momentum.",
+    "metrics": {
+      "balance": 420000,
+      "monthly_revenue": 52000,
+      "monthly_expenses": 130000,
+      "users": 2100,
+      "growth_rate": 0.12,
+      "churn_rate": 0.05,
+      "product_quality": 55.0,
+      "brand_awareness": 50.0,
+      "team_morale": 68.0,
+      "headcount": 20
+    }
+  },
+  {
+    "name": "Enterprise B2B",
+    "description": "Sales-led platform targeting large, contract-heavy accounts.",
+    "metrics": {
+      "balance": 600000,
+      "monthly_revenue": 70000,
+      "monthly_expenses": 140000,
+      "users": 800,
+      "growth_rate": 0.05,
+      "churn_rate": 0.025,
+      "product_quality": 65.0,
+      "brand_awareness": 35.0,
+      "team_morale": 74.0,
+      "headcount": 24
     }
   }
 ]


### PR DESCRIPTION
## Summary
- expand `actions.json` to cover ten gameplay decisions with balanced costs, effects, and risks
- grow `events.json` into an eleven-item set with varied durations and reversible impacts
- seed `startup_profiles.json` with three themed starting line-ups and document the data files in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e34fe678b88327bf6ecc3a22fe9258