### PR TITLE
Centralize balancing constants and clamp policy

### DIFF
--- a/startup_simulator/actions.py
+++ b/startup_simulator/actions.py
@@ -185,8 +185,12 @@ def list_actions(startup: Startup) -> list[Action]:
 
 def _clamp_turn_limit(limit: int | None) -> int:
     if limit is None:
-        limit = config.MAX_ACTIONS_PER_TURN
-    return max(1, min(3, limit))
+        limit = config.DEFAULT_ACTIONS_PER_TURN
+    minimum, maximum = config.ACTION_LIMIT_RANGE
+    limit = max(minimum, limit)
+    if maximum is not None:
+        limit = min(maximum, limit)
+    return limit
 
 
 def validate_action_limit(

--- a/startup_simulator/config.py
+++ b/startup_simulator/config.py
@@ -1,35 +1,121 @@
-"""Configuration constants for the Startup Simulator package."""
+"""Central configuration for Startup Simulator balancing and persistence.
+
+Designers can safely tweak the values in this module to rebalance the game
+without touching the gameplay code. Whenever you adjust a knob here the rest
+of the codebase will automatically pick up the change the next time the game
+runs. A few guidelines when editing:
+
+* Keep numeric ranges consistent. For example, if you raise the cap for
+  ``product_quality`` in :data:`STARTUP_PERCENT_BOUNDS`, consider adjusting
+  related UI copy or event logic that references high quality scores.
+* Company valuation multipliers in :data:`COMPANY_VALUE_WEIGHTS` directly
+  influence how different aspects of the startup contribute to its heuristic
+  valuation. Increase a weight to make that component matter more, decrease it
+  to reduce its influence. ``bug_rate`` should remain negative so higher bug
+  rates continue to penalise the valuation.
+* ``ACTION_LIMIT_RANGE`` defines the hard clamp the simulator will apply to any
+  per-turn action limit, regardless of whether it comes from designer authored
+  content or command line overrides.
+
+All constants exposed here are imported by other modules; renaming them will
+require updating the associated imports.
+"""
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Mapping
 
-# General simulation configuration
+# ---------------------------------------------------------------------------
+# Core file paths and persistence knobs
+# ---------------------------------------------------------------------------
+
 GAME_TITLE: str = "Startup Simulator"
 DEFAULT_SEED: int = 42
-AUTOSAVE_FILENAME: str = "save.json"
-DATA_DIRECTORY: Path = Path(__file__).resolve().parent / "data"
-SAVE_SCHEMA_VERSION: str = "1.0"
 
-# Financial tuning parameters
+DATA_DIRECTORY: Path = Path(__file__).resolve().parent / "data"
+AUTOSAVE_FILENAME: str = "save.json"
+SAVE_SCHEMA_VERSION: str = "1.0"
+DEFAULT_SAVE_PATH: Path = Path(AUTOSAVE_FILENAME)
+
+# ---------------------------------------------------------------------------
+# Economy and gameplay pacing
+# ---------------------------------------------------------------------------
+
 DEFAULT_STARTING_FUNDS: float = 500_000.0
 MONTHLY_BURN_CAP: float = 120_000.0
-REVENUE_GROWTH_WEIGHT: float = 1.1
-EXPENSE_GROWTH_WEIGHT: float = 1.05
 
-# Gameplay
-MAX_ACTIONS_PER_TURN: int = 2
+DEFAULT_ACTIONS_PER_TURN: int = 2
+# Designers can expand the action range, but values below 1 make the game
+# unwinnable and values above ~5 tend to trivialise encounters.
+ACTION_LIMIT_RANGE: tuple[int, int] = (1, 3)
+
 EVENT_PROBABILITY_WEIGHT: float = 0.35
+
+# ---------------------------------------------------------------------------
+# Generic numeric ranges used for clamping
+# ---------------------------------------------------------------------------
+
+PROBABILITY_RANGE: tuple[float, float] = (0.0, 1.0)
+METRIC_VALUE_RANGE: tuple[float, float] = (0.0, 100.0)
+
+STARTUP_INT_BOUNDS: Mapping[str, tuple[int, int | None]] = {
+    "balance": (0, None),
+    "monthly_revenue": (0, None),
+    "monthly_expenses": (0, None),
+    "users": (0, None),
+    "headcount": (0, None),
+    "debt": (0, None),
+    "turn": (0, None),
+}
+
+STARTUP_PERCENT_BOUNDS: Mapping[str, tuple[float, float]] = {
+    "product_quality": (0.0, 100.0),
+    "brand_awareness": (0.0, 100.0),
+    "team_morale": (0.0, 100.0),
+}
+
+STARTUP_RATE_BOUNDS: Mapping[str, tuple[float, float]] = {
+    "growth_rate": (0.0, 1.0),
+    "churn_rate": (0.0, 1.0),
+}
+
+STARTUP_INT_FIELDS: tuple[str, ...] = tuple(STARTUP_INT_BOUNDS.keys())
+
+# ---------------------------------------------------------------------------
+# Company valuation tuning
+# ---------------------------------------------------------------------------
+
+COMPANY_VALUE_WEIGHTS: Mapping[str, float] = {
+    "revenue": 1.1,
+    "market_share": 30.0,
+    "reputation": 1_000.0,
+    "team_size": 2_000.0,
+    "bug_rate": -200_000.0,
+}
+COMPANY_EXPENSE_WEIGHT: float = 1.05
+
+# ---------------------------------------------------------------------------
+# Public export surface
+# ---------------------------------------------------------------------------
 
 __all__ = [
     "GAME_TITLE",
     "DEFAULT_SEED",
-    "AUTOSAVE_FILENAME",
     "DATA_DIRECTORY",
+    "AUTOSAVE_FILENAME",
     "SAVE_SCHEMA_VERSION",
+    "DEFAULT_SAVE_PATH",
     "DEFAULT_STARTING_FUNDS",
     "MONTHLY_BURN_CAP",
-    "REVENUE_GROWTH_WEIGHT",
-    "EXPENSE_GROWTH_WEIGHT",
-    "MAX_ACTIONS_PER_TURN",
+    "DEFAULT_ACTIONS_PER_TURN",
+    "ACTION_LIMIT_RANGE",
     "EVENT_PROBABILITY_WEIGHT",
+    "PROBABILITY_RANGE",
+    "METRIC_VALUE_RANGE",
+    "STARTUP_INT_BOUNDS",
+    "STARTUP_PERCENT_BOUNDS",
+    "STARTUP_RATE_BOUNDS",
+    "STARTUP_INT_FIELDS",
+    "COMPANY_VALUE_WEIGHTS",
+    "COMPANY_EXPENSE_WEIGHT",
 ]

--- a/startup_simulator/player.py
+++ b/startup_simulator/player.py
@@ -16,7 +16,13 @@ class Metric:
 
     def apply_delta(self, delta: float) -> None:
         """Apply a change to the metric value while keeping it within sensible bounds."""
-        self.value = max(0.0, min(100.0, self.value + delta))
+        minimum, maximum = config.METRIC_VALUE_RANGE
+        updated = self.value + delta
+        if minimum is not None:
+            updated = max(minimum, updated)
+        if maximum is not None:
+            updated = min(maximum, updated)
+        self.value = updated
 
 
 @dataclass(slots=True)
@@ -31,7 +37,7 @@ class PlayerState:
 
     def record_action(self, action_key: str) -> None:
         """Record that the player has taken the specified action this turn."""
-        if len(self.actions_taken) >= config.MAX_ACTIONS_PER_TURN:
+        if len(self.actions_taken) >= config.DEFAULT_ACTIONS_PER_TURN:
             raise ValueError("Action limit reached for this turn.")
         self.actions_taken.append(action_key)
 

--- a/startup_simulator/save_system.py
+++ b/startup_simulator/save_system.py
@@ -10,8 +10,8 @@ from . import config
 from .startup import Startup
 
 
-SCHEMA_VERSION: str = getattr(config, "SAVE_SCHEMA_VERSION", "1.0")
-SAVE_PATH: Path = Path(getattr(config, "AUTOSAVE_FILENAME", "save.json"))
+SCHEMA_VERSION: str = config.SAVE_SCHEMA_VERSION
+SAVE_PATH: Path = getattr(config, "DEFAULT_SAVE_PATH", Path(config.AUTOSAVE_FILENAME))
 _REQUIRED_KEYS: tuple[str, ...] = ("version", "timestamp", "turn", "rng_seed", "startup")
 
 

--- a/startup_simulator/tests/test_actions.py
+++ b/startup_simulator/tests/test_actions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 
-from startup_simulator import actions
+from startup_simulator import actions, config
 from startup_simulator.startup import Startup
 from startup_simulator.tests.utils import PatchManager, expect_raises
 
@@ -45,7 +45,8 @@ def test_apply_action_deducts_cost_and_clamps() -> None:
         updated, narrative = actions.apply_action(state, "clamp_test", random.Random(1))
 
     assert updated.balance == 500
-    assert updated.product_quality == 100.0
+    max_quality = config.STARTUP_PERCENT_BOUNDS["product_quality"][1]
+    assert updated.product_quality == max_quality
     assert narrative == "Testing narrative."
 
 


### PR DESCRIPTION
## Summary
- expose action limits, stat ranges, company valuation weights, and save metadata through the shared config module with designer documentation
- update startup, player, action, and event logic to clamp values and compute company value using the config-driven ranges and weights
- align saving utilities and tests with the centralized configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e360db7034832796c0b6da6d5b644d